### PR TITLE
Fix problem with using local quantities where world frame was expected

### DIFF
--- a/demos/demo_robot_com_ctrl_cpp.py
+++ b/demos/demo_robot_com_ctrl_cpp.py
@@ -114,6 +114,8 @@ def demo(robot_name):
         # Read the final state and forces after the stepping.
         q, dq = robot.get_state()
 
+	quat = pin.Quaternion(q[6], q[3], q[4], q[5])
+
         # computing forces to be applied in the centroidal space
         centrl_pd_ctrl.run(
             kc,
@@ -122,7 +124,7 @@ def demo(robot_name):
             db,
             q[:3],
             x_com,
-            dq[:3],
+            quat.toRotationMatrix().dot(dq[:3]), # local to world frame
             xd_com,
             q[3:7],
             x_ori,

--- a/include/mim_control/centroidal_pd_controller.hpp
+++ b/include/mim_control/centroidal_pd_controller.hpp
@@ -70,6 +70,9 @@ private:  // attributes
     Eigen::Vector3d vel_error_;
     Eigen::Vector3d ori_error_;
 
+    Eigen::Vector3d angvel_world_error_;
+    Eigen::Vector3d des_angvel_world_error_;
+
     Eigen::Quaternion<double> ori_quat_;
     Eigen::Quaternion<double> des_ori_quat_;
     Eigen::Quaternion<double> ori_error_quat_;
@@ -78,6 +81,8 @@ private:  // attributes
     Eigen::Matrix<double, 3, 3> des_ori_se3_;
     Eigen::Matrix<double, 3, 3>
         ori_error_se3_;  // refer to christian ott paper for definitions (Rdb)
+
+
 };
 
 }  // namespace mim_control

--- a/include/mim_control/centroidal_pd_controller.hpp
+++ b/include/mim_control/centroidal_pd_controller.hpp
@@ -81,8 +81,6 @@ private:  // attributes
     Eigen::Matrix<double, 3, 3> des_ori_se3_;
     Eigen::Matrix<double, 3, 3>
         ori_error_se3_;  // refer to christian ott paper for definitions (Rdb)
-
-
 };
 
 }  // namespace mim_control

--- a/python/mim_control/robot_centroidal_controller.py
+++ b/python/mim_control/robot_centroidal_controller.py
@@ -51,7 +51,6 @@ class RobotCentroidalController:
         self.eff_ids = self.robot_config.end_eff_ids
         self.qp_penalty_lin = qp_penalty_lin
         self.qp_penalty_ang = qp_penalty_ang
-        self.rotate_vel_error = False
 
     def compute_com_wrench(self, q, dq, des_pos, des_vel, des_ori, des_angvel):
         """Compute the desired COM wrench (equation 1).
@@ -75,15 +74,17 @@ class RobotCentroidalController:
 
         cur_angvel = arr(dq[3:6])
 
-        if self.rotate_vel_error:
-            # Rotate the des and current angular velocity into the world frame.
-            quat_des = pin.Quaternion(
-                des_ori[3], des_ori[0], des_ori[1], des_ori[2]
-            ).matrix()
-            des_angvel = quat_des.dot(des_angvel)
+        # Rotate the des and current angular velocity into the world frame.
+        quat_des = pin.Quaternion(
+            des_ori[3], des_ori[0], des_ori[1], des_ori[2]
+        ).matrix()
+        des_angvel = quat_des.dot(des_angvel)
 
-            quat_cur = pin.Quaternion(q[6], q[3], q[4], q[5]).matrix()
-            cur_angvel = quat_cur.dot(cur_angvel)
+        quat_cur = pin.Quaternion(q[6], q[3], q[4], q[5]).matrix()
+        cur_angvel = quat_cur.dot(cur_angvel)
+
+        # Rotate the base velocity into global frame as well.
+        vcom = quat_cur.dot(vcom)
 
         w_com = np.hstack(
             [


### PR DESCRIPTION
Basically, when computing the centroidal wrench using the PD on the com and base orientation we mixed up local and world frame coordinates. This PR fixes this. Leave some comments inline that hopefully makes things more clear.