### PR TITLE
Adding centroidal_impedance_controller for speed reasons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,8 @@ add_library(
   ${PROJECT_NAME} SHARED
   src/impedance_controller.cpp
   src/centroidal_pd_controller.cpp
-  src/centroidal_force_qp_controller.cpp)
+  src/centroidal_force_qp_controller.cpp
+  src/centroidal_impedance_controller.cpp)
 # cmake-format: on
 target_link_libraries(${PROJECT_NAME} pinocchio::pinocchio)
 target_link_libraries(${PROJECT_NAME} Eigen3::Eigen)
@@ -127,7 +128,8 @@ pybind11_add_module(${PROJECT_NAME}_cpp MODULE
   srcpy/${PROJECT_NAME}.cpp
   srcpy/impedance_controller.cpp
   srcpy/centroidal_pd_controller.cpp
-  srcpy/centroidal_force_qp_controller.cpp)
+  srcpy/centroidal_force_qp_controller.cpp
+  srcpy/centroidal_impedance_controller.cpp)
 # cmake-format: on
 target_link_libraries(${PROJECT_NAME}_cpp PRIVATE pybind11::module)
 target_link_libraries(${PROJECT_NAME}_cpp PRIVATE ${PROJECT_NAME})

--- a/demos/demo_robot_com_imp_ctrl_cpp.py
+++ b/demos/demo_robot_com_imp_ctrl_cpp.py
@@ -1,0 +1,115 @@
+"""This file is the centroidal controller demo for solo12 using the C++ code.
+
+License BSD-3-Clause
+Copyright (c) 2020, New York University and Max Planck Gesellschaft.
+
+Author: Julian Viereck
+"""
+
+import argparse
+import numpy as np
+import pinocchio
+from mim_control_cpp import (
+    CentroidalImpedanceController
+)
+from bullet_utils.env import BulletEnvWithGround
+from robot_properties_solo.solo12wrapper import Solo12Robot, Solo12Config
+
+import time
+
+def demo(robot_name):
+    # Create a Pybullet simulation environment
+    env = BulletEnvWithGround()
+
+    # Create a robot instance in the simulator.
+    robot = Solo12Robot()
+    robot = env.add_robot(robot)
+    robot_config = Solo12Config()
+    mu = 0.2
+    kc = np.array([200, 200, 200])
+    dc = np.array([50, 50, 50])
+    kb = np.array([100, 100, 200])
+    db = np.array([50.0, 50.0, 200.0])
+    qp_penalty_weights = np.array([5e5, 5e5, 5e5, 1e6, 1e6, 1e6])
+
+    # impedance gains
+    kp = np.array([200, 200, 200, 0, 0, 0])
+    kd = np.array([10.0, 10.0, 10.0, 0, 0, 0])
+
+    pin_robot = robot.pin_robot
+
+    q_init = robot_config.q0.copy()
+    q_init[0] = 0.
+
+    robot.reset_state(q_init, robot_config.v0)
+
+    ctrl = CentroidalImpedanceController()
+    ctrl.initialize(
+        2.5,
+        np.diag(robot.pin_robot.mass(q_init)[3:6, 3:6]),
+        pin_robot.model,
+        "universe",
+        robot_config.end_effector_names,
+        mu,
+        qp_penalty_weights,
+        kc, dc, kb, db,
+        kp, kd
+    )
+
+    # Desired center of mass position and velocity.
+    x_com = [0.0, 0.0, 0.25]
+    xd_com = [0.0, 0.0, 0.0]
+    # The base should be flat.
+    x_ori = [0.0, 0.0, 0.0, 1.0]
+    x_angvel = [0.0, 0.0, 0.0]
+
+    # Desired leg length
+    x_des = [
+         0.195,  0.147, 0.015, 0, 0, 0, 1.,
+         0.195, -0.147, 0.015, 0, 0, 0, 1.,
+        -0.195,  0.147, 0.015, 0, 0, 0, 1.,
+        -0.195, -0.147, 0.015, 0, 0, 0, 1.
+    ]
+    xd_des = np.zeros(4 * 6)
+
+    dur = 0.
+
+    # Run the simulator for N steps
+    N = 4000
+    for _ in range(N):
+        # Read the final state and forces after the stepping.
+        q, dq = robot.get_state()
+
+        quat = pinocchio.Quaternion(q[6], q[3], q[4], q[5])
+        quat.normalize()
+
+        start = time.time()
+        ctrl.run(
+            q, dq,
+            np.array([1., 1., 1., 1.]),
+            q[:3],
+            x_com,
+            quat.toRotationMatrix().dot(dq[:3]), # local to world frame
+            xd_com,
+            q[3:7],
+            x_ori,
+            dq[3:6],
+            x_angvel,
+            x_des, xd_des
+        )
+
+        tau = ctrl.get_joint_torques()
+        dur += time.time() - start
+
+        # passing torques to the robot
+        robot.send_joint_command(tau)
+
+        # Step the simulator.
+        env.step(
+            sleep=False
+        )  # You can sleep here if you want to slow down the replay
+
+    print('Control path: %0.3f ms' % (dur * 1000. / N))
+
+if __name__ == "__main__":
+    demo('solo12')

--- a/include/mim_control/centroidal_impedance_controller.hpp
+++ b/include/mim_control/centroidal_impedance_controller.hpp
@@ -1,0 +1,110 @@
+/**
+ * @file
+ * @license BSD 3-clause
+ * @copyright Copyright (c) 2020, New York University and Max Planck
+ * Gesellschaft
+ *
+ * @brief This is the implementation for impedance controller between any two
+ * frames of the robot.
+ *
+ */
+
+#pragma once
+
+#include "pinocchio/multibody/data.hpp"
+#include "pinocchio/multibody/model.hpp"
+
+#include "mim_control/centroidal_force_qp_controller.hpp"
+#include "mim_control/centroidal_pd_controller.hpp"
+#include "mim_control/impedance_controller.hpp"
+
+
+namespace mim_control
+{
+/**
+ * @brief Controller for running centroidal pd, force qp and impedance at once.
+ */
+class CentroidalImpedanceController
+{
+public:
+    typedef Eigen::Array<double, 6, 1> Array6d;
+    typedef Eigen::Matrix<double, 6, 1> Vector6d;
+
+    /**
+     * @brief Construct a new CentroidalImpedanceController object.
+     */
+    CentroidalImpedanceController();
+
+    /**
+     * @brief Initialize the internal data. None real-time safe method.
+     *
+     * @param pinocchio_model rigid body model of the robot
+     * @param root_frame_name root frame name where the spring starts(Ex. Hip)
+     * @param end_frame_name frame name where the spring ends(Ex. end effector)
+     */
+    void initialize(const double& mass,
+                    Eigen::Ref<const Eigen::Vector3d> inertia,
+                    const pinocchio::Model& pinocchio_model,
+                    const std::string& root_frame_name,
+                    const std::vector<std::string>& end_frame_names,
+                    double friction_coeff,
+                    Eigen::Ref<const Vector6d> qp_penalty_weights,
+                    Eigen::Ref<const Eigen::Vector3d> kc,
+                    Eigen::Ref<const Eigen::Vector3d> dc,
+                    Eigen::Ref<const Eigen::Vector3d> kb,
+                    Eigen::Ref<const Eigen::Vector3d> db,
+                    Eigen::Ref<const Array6d> frame_placement_error_gain,
+                    Eigen::Ref<const Array6d> frame_velocity_error_gain);
+
+    void update_centroidal_gains(Eigen::Ref<const Eigen::Vector3d> kc,
+                                 Eigen::Ref<const Eigen::Vector3d> dc,
+                                 Eigen::Ref<const Eigen::Vector3d> kb,
+                                 Eigen::Ref<const Eigen::Vector3d> db);
+
+    void update_endeff_gains(Eigen::Ref<const Array6d> frame_placement_error_gain,
+                             Eigen::Ref<const Array6d> frame_velocity_error_gain);
+
+    void run(Eigen::Ref<const Eigen::VectorXd> robot_configuration,
+             Eigen::Ref<const Eigen::VectorXd> robot_velocity,
+             Eigen::Ref<const Eigen::VectorXd> cnt_array,
+             Eigen::Ref<const Eigen::Vector3d> com,
+             Eigen::Ref<const Eigen::Vector3d> com_des,
+             Eigen::Ref<const Eigen::Vector3d> vcom,
+             Eigen::Ref<const Eigen::Vector3d> vcom_des,
+             Eigen::Ref<const Eigen::Vector4d> ori,
+             Eigen::Ref<const Eigen::Vector4d> ori_des,
+             Eigen::Ref<const Eigen::Vector3d> angvel,
+             Eigen::Ref<const Eigen::Vector3d> angvel_des,
+             Eigen::Ref<const Eigen::VectorXd> desired_end_frame_placement,
+             Eigen::Ref<const Eigen::VectorXd> desired_end_frame_velocity);
+
+    /**
+     * @brief Get the computed joint torques from the impedance controller.
+     *
+     * @return Eigen::VectorXd&
+     */
+    const Eigen::VectorXd& get_joint_torques();
+
+private:
+    /** @brief Rigid body dynamics model. */
+    pinocchio::Model pinocchio_model_;
+
+    /** @brief Cache of the rigid body dynamics algorithms. */
+    pinocchio::Data pinocchio_data_;
+
+    Eigen::Vector3d kc_;
+    Eigen::Vector3d dc_;
+    Eigen::Vector3d kb_;
+    Eigen::Vector3d db_;
+    Array6d frame_placement_error_gain_;
+    Array6d frame_velocity_error_gain_;
+
+    Eigen::VectorXd joint_torques_;
+    Eigen::VectorXd relative_position_endeff_;
+
+    CentroidalPDController centroidal_pd_controller_;
+    CentroidalForceQPController centroidal_force_qp_controller_;
+    std::vector<ImpedanceController> impedance_controllers_;
+};
+
+}  // namespace mim_control

--- a/include/mim_control/impedance_controller.hpp
+++ b/include/mim_control/impedance_controller.hpp
@@ -90,6 +90,31 @@ public:
              const pinocchio::Motion& desired_end_frame_velocity,
              const pinocchio::Force& feed_forward_force);
 
+
+    /**
+     * @brief Similar to `run()` but with the data already precomputed.
+     *
+     * @param pinocchio_data The data object to use for the computation.
+     * @param gain_proportional 6d vector for the proportional gains on {x, y,
+     * z, roll, pitch, yaw}.
+     * @param gain_derivative 6d vector for the proportional gains on {x, y, z,
+     * roll, pitch, yaw}.
+     * @param gain_feed_forward_force gain multiplying the feed forward force.
+     * @param desired_end_frame_placement desired end frame placement relative
+     * to the desired root joint.
+     * @param desired_end_frame_velocity desired end frame velocity relative to
+     * the desired root joint.
+     * @param feed_forward_force feed forward force applied to the foot by the
+     * environment.
+     */
+    void run_precomputed_data(pinocchio::Data& pinocchio_data,
+                              Eigen::Ref<const Array6d> gain_proportional,
+                              Eigen::Ref<const Array6d> gain_derivative,
+                              const double& gain_feed_forward_force,
+                              const pinocchio::SE3& desired_end_frame_placement,
+                              const pinocchio::Motion& desired_end_frame_velocity,
+                              const pinocchio::Force& feed_forward_force);
+
     /**
      * @brief Get the computed torques from the impedance controller.
      *
@@ -110,6 +135,13 @@ public:
      * @return Vector6d&
      */
     const Vector6d& get_impedance_force();
+
+    /**
+     * @brief Returns the index of the endeffector frame.
+     *
+     * @return pinocchio::FrameIndex
+     */
+    const pinocchio::FrameIndex& get_endframe_index();
 
 private:  // attributes
     /** @brief Rigid body dynamics model. */

--- a/src/centroidal_impedance_controller.cpp
+++ b/src/centroidal_impedance_controller.cpp
@@ -1,0 +1,190 @@
+/**
+ * @file
+ * @license BSD 3-clause
+ * @copyright Copyright (c) 2021, New York University and Max Planck
+ * Gesellschaft
+ *
+ * @brief Implements the CentroidalImpedance controller.
+ */
+
+#include "mim_control/centroidal_impedance_controller.hpp"
+
+#include "pinocchio/algorithm/frames.hpp"
+
+namespace mim_control
+{
+CentroidalImpedanceController::CentroidalImpedanceController()
+{
+}
+
+void CentroidalImpedanceController::initialize(
+    const double& mass,
+    Eigen::Ref<const Eigen::Vector3d> inertia,
+    const pinocchio::Model& pinocchio_model,
+    const std::string& root_frame_name,
+    const std::vector<std::string>& end_frame_names,
+    double friction_coeff,
+    Eigen::Ref<const Vector6d> qp_penalty_weights,
+    Eigen::Ref<const Eigen::Vector3d> kc,
+    Eigen::Ref<const Eigen::Vector3d> dc,
+    Eigen::Ref<const Eigen::Vector3d> kb,
+    Eigen::Ref<const Eigen::Vector3d> db,
+    Eigen::Ref<const Array6d> frame_placement_error_gain,
+    Eigen::Ref<const Array6d> frame_velocity_error_gain
+)
+{
+    bool is_free_flyer =
+        pinocchio_model.joints[1].shortname() == "JointModelFreeFlyer";
+
+    kc_ = kc;
+    dc_ = dc;
+    kb_ = kb;
+    db_ = db;
+    frame_placement_error_gain_ = frame_placement_error_gain;
+    frame_velocity_error_gain_ = frame_velocity_error_gain;
+
+    pinocchio_model_ = pinocchio_model;
+
+    if (is_free_flyer) {
+        joint_torques_.resize(pinocchio_model.nv - 6);
+    } else {
+        joint_torques_.resize(pinocchio_model.nv);
+    }
+
+    // Create the cache of the rigid body dynamics algorithms
+    pinocchio_data_ = pinocchio::Data(pinocchio_model_);
+
+    int num_endeff = end_frame_names.size();
+
+    relative_position_endeff_.resize(3 * num_endeff);
+
+    // Initialize the other controllers.
+    centroidal_pd_controller_.initialize(mass, inertia);
+
+    centroidal_force_qp_controller_.initialize(
+        num_endeff,
+        friction_coeff,
+        qp_penalty_weights
+    );
+
+    impedance_controllers_.resize(num_endeff);
+    for (int i = 0; i < num_endeff; i++)
+    {
+        impedance_controllers_[i].initialize(
+            pinocchio_model_,
+            root_frame_name, end_frame_names[i]);
+    }
+}
+
+void CentroidalImpedanceController::update_centroidal_gains(
+                            Eigen::Ref<const Eigen::Vector3d> kc,
+                            Eigen::Ref<const Eigen::Vector3d> dc,
+                            Eigen::Ref<const Eigen::Vector3d> kb,
+                            Eigen::Ref<const Eigen::Vector3d> db)
+{
+    kc_ = kc;
+    dc_ = dc;
+    kb_ = kb;
+    db_ = db;
+}
+
+void CentroidalImpedanceController::update_endeff_gains(
+                        Eigen::Ref<const Array6d> frame_placement_error_gain,
+                        Eigen::Ref<const Array6d> frame_velocity_error_gain)
+{
+    frame_placement_error_gain_ = frame_placement_error_gain;
+    frame_velocity_error_gain_ = frame_velocity_error_gain;
+}
+
+void CentroidalImpedanceController::run(
+    Eigen::Ref<const Eigen::VectorXd> robot_configuration,
+    Eigen::Ref<const Eigen::VectorXd> robot_velocity,
+    Eigen::Ref<const Eigen::VectorXd> cnt_array,
+    Eigen::Ref<const Eigen::Vector3d> com,
+    Eigen::Ref<const Eigen::Vector3d> com_des,
+    Eigen::Ref<const Eigen::Vector3d> vcom,
+    Eigen::Ref<const Eigen::Vector3d> vcom_des,
+    Eigen::Ref<const Eigen::Vector4d> ori,
+    Eigen::Ref<const Eigen::Vector4d> ori_des,
+    Eigen::Ref<const Eigen::Vector3d> angvel,
+    Eigen::Ref<const Eigen::Vector3d> angvel_des,
+    Eigen::Ref<const Eigen::VectorXd> desired_end_frame_placement,
+    Eigen::Ref<const Eigen::VectorXd> desired_end_frame_velocity
+)
+{
+    //////
+    // Compute the desired centroidal wrench.
+    centroidal_pd_controller_.run(
+        kc_, dc_, kb_, db_, com, com_des, vcom, vcom_des, ori, ori_des,
+        angvel, angvel_des);
+
+    Vector6d& w_com = centroidal_pd_controller_.get_wrench();
+
+    //////
+    // Compute the forces at the endeffectors.
+
+    // Compute the relative positions of the endffectors.
+    int num_endeff = impedance_controllers_.size();
+    for (int i = 0; i < num_endeff; i++)
+    {
+        auto idx = impedance_controllers_[i].get_endframe_index();
+        relative_position_endeff_.block<3, 1>(3 * i, 0) = (
+            pinocchio_data_.oMf[idx].translation() - com
+        );
+    }
+
+    centroidal_force_qp_controller_.run(
+        w_com, relative_position_endeff_, cnt_array);
+
+    Eigen::VectorXd& forces = centroidal_force_qp_controller_.get_forces();
+
+    //////
+    // Update the pinocchio data.
+    pinocchio::forwardKinematics(
+        pinocchio_model_, pinocchio_data_, robot_configuration, robot_velocity);
+    pinocchio::updateFramePlacements(
+        pinocchio_model_, pinocchio_data_);
+    pinocchio::computeJointJacobians(
+        pinocchio_model_, pinocchio_data_, robot_configuration);
+
+    //////
+    // Compute the joint torques.
+    joint_torques_.fill(0);
+
+    for (int i = 0; i < num_endeff; i++)
+    {
+        pinocchio::SE3::Quaternion q (
+            desired_end_frame_placement[i * 7 + 6],
+            desired_end_frame_placement[i * 7 + 3],
+            desired_end_frame_placement[i * 7 + 4],
+            desired_end_frame_placement[i * 7 + 5]);
+        pinocchio::SE3::Vector3 t (
+            desired_end_frame_placement[i * 7 + 0],
+            desired_end_frame_placement[i * 7 + 1],
+            desired_end_frame_placement[i * 7 + 2]);
+
+        pinocchio::SE3 pos(q.matrix(), t);
+        pinocchio::Motion vel(desired_end_frame_velocity.block<6, 1>(i * 6, 0));
+
+        Vector6d f;
+        f.fill(0);
+        f.head<3>() = forces.block<3, 1>(3 * i, 0);
+        pinocchio::Force F(f);
+
+        impedance_controllers_[i].run_precomputed_data(
+            pinocchio_data_,
+            frame_placement_error_gain_, frame_velocity_error_gain_,
+            1.,
+            pos, vel, F
+        );
+
+        joint_torques_ += impedance_controllers_[i].get_joint_torques();
+    }
+}
+
+const Eigen::VectorXd& CentroidalImpedanceController::get_joint_torques()
+{
+    return joint_torques_;
+}
+
+}

--- a/srcpy/centroidal_impedance_controller.cpp
+++ b/srcpy/centroidal_impedance_controller.cpp
@@ -1,0 +1,62 @@
+/**
+ * @file
+ * @license BSD 3-clause
+ * @copyright Copyright (c) 2020, New York University and Max Planck
+ * Gesellschaft
+ *
+ * @brief Python bindings for the CentroidalPDController class.
+ */
+
+#include "mim_control/centroidal_impedance_controller.hpp"
+#include <pybind11/eigen.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+#include <pybind11/pybind11.h>
+#include <boost/python.hpp>
+
+namespace py = pybind11;
+
+namespace mim_control
+{
+void bind_centroidal_impedance_controller(py::module& module)
+{
+    py::class_<CentroidalImpedanceController>(module, "CentroidalImpedanceController")
+        .def(py::init<>())
+
+        // Public methods.
+        // .def("initialize", &CentroidalImpedanceController::initialize)
+        .def("initialize",
+             [](CentroidalImpedanceController& obj,
+                const double& mass,
+                Eigen::Ref<const Eigen::Vector3d> inertia,
+                py::object model,
+                const std::string& root_frame_name,
+                const std::vector<std::string>& end_frame_names,
+                double friction_coeff,
+                Eigen::Ref<const Vector6d> qp_penalty_weights,
+                Eigen::Ref<const Eigen::Vector3d> kc,
+                Eigen::Ref<const Eigen::Vector3d> dc,
+                Eigen::Ref<const Eigen::Vector3d> kb,
+                Eigen::Ref<const Eigen::Vector3d> db,
+                Eigen::Ref<const Array6d> frame_placement_error_gain,
+                Eigen::Ref<const Array6d> frame_velocity_error_gain) {
+                 const pinocchio::Model& pinocchio_model =
+                     boost::python::extract<const pinocchio::Model&>(
+                         model.ptr());
+                 obj.initialize(
+                     mass, inertia, pinocchio_model, root_frame_name,
+                     end_frame_names, friction_coeff, qp_penalty_weights,
+                     kc, dc, kb, db,
+                     frame_placement_error_gain, frame_velocity_error_gain);
+                 return;
+             })
+
+        .def("update_centroidal_gains", &CentroidalImpedanceController::update_centroidal_gains)
+        .def("update_endeff_gains", &CentroidalImpedanceController::update_centroidal_gains)
+        .def("run", &CentroidalImpedanceController::run)
+        .def("get_joint_torques",
+             &CentroidalImpedanceController::get_joint_torques,
+             py::return_value_policy::reference);
+}
+
+}  // namespace mim_control

--- a/srcpy/mim_control.cpp
+++ b/srcpy/mim_control.cpp
@@ -14,6 +14,7 @@ namespace mim_control
 void bind_impedance_controller(pybind11::module &module);
 void bind_centroidal_pd_controller(pybind11::module &module);
 void bind_centroidal_force_qp_controller(pybind11::module &module);
+void bind_centroidal_impedance_controller(pybind11::module &module);
 
 PYBIND11_MODULE(mim_control_cpp, m)
 {
@@ -30,6 +31,7 @@ PYBIND11_MODULE(mim_control_cpp, m)
     bind_impedance_controller(m);
     bind_centroidal_pd_controller(m);
     bind_centroidal_force_qp_controller(m);
+    bind_centroidal_impedance_controller(m);
 }
 
 }  // namespace mim_control


### PR DESCRIPTION
At the moment running the centroidal pd, qp and impedance controller requires to construct 3 different classes and then pass data from one of them to the next. In addition, we compute the data in the impedance controller multiple times / once per impedance controller.

This PR implements a new `centroidal_impedance_controller`, which uses the 3 controllers from C++ and exposes a single python class. I've also changed the impedance controller, such that it can be called with the data precomputed. This allows to compute the data only once.

Comparing the performance of 3 individual controllers vs one centroidal controller, I found these values when running the same setup from python on my MacBook:

| Type | Runtime [ms] |
|-------|-------------|
| 3 individual controllers | 0.239 ms / iteration |
| single / centroidal_impedance_controller | 0.064 ms / iteration |

This means the centroidal_impedance_controller is ~3.73x faster then the individual controllers.


